### PR TITLE
Enable highlighting of m68k syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
     # Compile all sources
     - docker run --rm -v $PWD/src:/data -w /data nguillaumin/vasm make
     # Generate HTML from AsciiDoc
-    - docker run --rm -v $PWD:/documents asciidoctor/docker-asciidoctor asciidoctor -a docinfo1 *.adoc
+    - docker run --rm -v $PWD:/documents asciidoctor/docker-asciidoctor bash -c "gem install asciidoctor-rouge; asciidoctor -r asciidoctor-rouge -a source-highligher=rouge -a docinfo1 *.adoc"
     # Remove files unnecessary on GitHub pages
     - rm -f .travis.yml
     - rm -f .gitignore

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,6 @@
 The Atari ST MC68000 Assembly Language Tutorials
 ================================================
+:source-language: m68k
 originally by perihelion of poSTmortem
 
 image:https://travis-ci.org/nguillaumin/perihelion-m68k-tutorials.svg?branch=master["Build Status", link="https://travis-ci.org/nguillaumin/perihelion-m68k-tutorials"]

--- a/index.adoc
+++ b/index.adoc
@@ -1,5 +1,6 @@
 The Atari ST MC68000 Assembly Language Tutorials
 ================================================
+:source-language: m68k
 perihelion of poSTmortem
 1st edition (v0.84), August 28th 2004 | edited by bp
 

--- a/tutorial-02.adoc
+++ b/tutorial-02.adoc
@@ -1,5 +1,6 @@
 Of The Workings Of Devpac 3 And The Realisation Of Some Code
 ============================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-14 (last edition of the initial revision)
 

--- a/tutorial-03.adoc
+++ b/tutorial-03.adoc
@@ -1,5 +1,6 @@
 Of Various Things Mystic And Important, Mainly Concerning The Art Of Understanding Digits And Performing Traps
 ==============================================================================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-14 (last edition of the initial revision)
 

--- a/tutorial-04.adoc
+++ b/tutorial-04.adoc
@@ -1,5 +1,6 @@
 Of The Ways Of Addressing Memory
 ================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-14 (last edition of the initial revision)
 

--- a/tutorial-05.adoc
+++ b/tutorial-05.adoc
@@ -1,5 +1,6 @@
 Of The Workings Of The Graphics Memory And Minor Skills In Branching
 ====================================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-01 (last edition of the initial revision)
 

--- a/tutorial-06.adoc
+++ b/tutorial-06.adoc
@@ -1,5 +1,6 @@
 Of Seeing Behind The Curtain Of An Execution And Getting Intimate With Files
 ============================================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-01 (last edition of the initial revision)
 

--- a/tutorial-07.adoc
+++ b/tutorial-07.adoc
@@ -1,5 +1,6 @@
 On Scrollers
 ============
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-14 (last edition of the initial revision)
 

--- a/tutorial-08.adoc
+++ b/tutorial-08.adoc
@@ -1,5 +1,6 @@
 Of Scrolling 8 Pixels Per VBL Using Double Buffer
 =================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-14 (last edition of the initial revision)
 

--- a/tutorial-09.adoc
+++ b/tutorial-09.adoc
@@ -1,5 +1,6 @@
 Of Revealing The Unseen And Expanding Our Consciousness Without The Use Of Illegal Drugs
 ========================================================================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-06 (last edition of the initial revision)
 

--- a/tutorial-10.adoc
+++ b/tutorial-10.adoc
@@ -1,5 +1,6 @@
 Of Lighting A Candle (And Casting A Shadow)
 ===========================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-06-23 (last edition of the initial revision)
 

--- a/tutorial-11.adoc
+++ b/tutorial-11.adoc
@@ -1,5 +1,6 @@
 Of Making The Mountain Move To Mohammed
 =======================================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-12 (last edition of the initial revision)
 

--- a/tutorial-12.adoc
+++ b/tutorial-12.adoc
@@ -1,5 +1,6 @@
 Of Controlling The Puppets
 ==========================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-13 (last edition of the initial revision)
 

--- a/tutorial-13.adoc
+++ b/tutorial-13.adoc
@@ -1,5 +1,6 @@
 Of Hearing That Which Is Spoken
 ===============================
+:source-language: m68k
 perihelion of poSTmortem
 2002-07-28 (last edition of the initial revision)
 

--- a/tutorial-14.adoc
+++ b/tutorial-14.adoc
@@ -1,5 +1,6 @@
 Of Using The Gramophone
 =======================
+:source-language: m68k
 perihelion of poSTmortem
 2003-02-22 (last edition of the initial revision)
 

--- a/tutorial-15.adoc
+++ b/tutorial-15.adoc
@@ -1,5 +1,6 @@
 On Fading To Black
 ==================
+:source-language: m68k
 perihelion of poSTmortem
 2002-03-28 (last edition of the initial revision)
 


### PR DESCRIPTION
Uses the m68k syntax I contributed on the Rouge project.

Unfortunately Rouge is not supported to highlight HTML out of the box
(only PDF), so an extra Gem is needed.