### PR TITLE
Fix Asciidoc syntax for inline # in tutorial 4

### DIFF
--- a/tutorial-01.adoc
+++ b/tutorial-01.adoc
@@ -206,7 +206,7 @@ Put #255 at $204
 Initialise monitor
 ....
 
-Now, as you can guess, `#` stands for value, a numerical value in our case, and `$` stands for
+Now, as you can guess, `+#+` stands for value, a numerical value in our case, and `$` stands for
 address. Now, if we compile this source code, that is, translate it to a format the computer
 understands, we will get a `.prg` file. When we double click on that file, the computer will do
 what it says above: the different values will be loaded into the different addresses, creating

--- a/tutorial-02.adoc
+++ b/tutorial-02.adoc
@@ -73,7 +73,7 @@ knowledge we enter this single line as our source code
 ----
 
 Move is the command used for moving values around other values, in this case, we move the
-value `#$700` into memory position `$ffff8240`. The `#` indicates that what comes after is an
+value `#$700` into memory position `$ffff8240`. The `+#+` indicates that what comes after is an
 absolute value, and the `$` means that the value is hexadecimal, instead of decimal (more on
 this later, accept for now). The `.w` after the move instruction means that the move instruction
 should move a word, indicating the size of the thing you want moved (more on this later also,

--- a/tutorial-03.adoc
+++ b/tutorial-03.adoc
@@ -101,10 +101,10 @@ F5A would be three thousand nine hundred and thirty (15 x 16^2 + 5 x 16^1 + 10 x
 don't get all this, this topic will probably be covered by every beginner's book and tutorial out
 there, go find an additional source of information.
 
-In Devpac, values are expressed by putting `#` in front of a number, then further using `$` or
-`%` before numbers to indicate hexadecimal or binary numbers. Thus, `#` means decimal, `#$`
-means hexadecimal value and `#%` means binary value. So, as you see, it's customary to
-express memory addresses in hexadecimal. `$` (without `#`) means value at memory address.
+In Devpac, values are expressed by putting `+#+` in front of a number, then further using `$` or
+`%` before numbers to indicate hexadecimal or binary numbers. Thus, `+#+` means decimal, `+#+$`
+means hexadecimal value and `+#+%` means binary value. So, as you see, it's customary to
+express memory addresses in hexadecimal. `$` (without `+#+`) means value at memory address.
 
 Huh, that was that, now onto the architecture of the Atari! Every computer comes with a
 processor of different (or similar) brands, the Atari has a M68000 processor, so does the

--- a/tutorial-04.adoc
+++ b/tutorial-04.adoc
@@ -176,7 +176,7 @@ position, is also known as the text you entered. Every line of source code has i
 value, which of course is some hex value, so instead of trying to figure out that hex value,
 you tell the assembler that "henceforth, this line shall be known as [whatever you write]".
 Also, any text written after the instruction, is treated as comments and are passed over by
-the assembler. You may also use a `*` to denote comments. Comments beginning with a `*`
+the assembler. You may also use a `+*+` to denote comments. Comments beginning with a `+*+`
 can be inserted everywhere.
 
 Disclaimer: the "actual memory position" values are purely for example and have nothing to

--- a/tutorial-04.adoc
+++ b/tutorial-04.adoc
@@ -117,10 +117,10 @@ clear with time I think, and especially after this example.
 |=======================
 
 As you might have noticed, if you studied the example thoroughly, when you want an
-address register to point to a place, you use `#` when giving the address, but when you want
-the content of the address of a memory location, you don't use `#`. Thus, if you want `a0` to
+address register to point to a place, you use `+#+` when giving the address, but when you want
+the content of the address of a memory location, you don't use `+#+`. Thus, if you want `a0` to
 point to `$100`, you use `move.l #$100, a0`. But if you want the value of memory address `$100`
-to be put into `d0`, you use `move.l $100, d0`. So, with a `#`, you have a value, but without `#`,
+to be put into `d0`, you use `move.l $100, d0`. So, with a `+#+`, you have a value, but without `+#+`,
 you have a pointer.
 
 I think that should cover it nicely. These memory addressing modes are our main concern,

--- a/tutorial-05.adoc
+++ b/tutorial-05.adoc
@@ -22,9 +22,9 @@ thought I'd take a quick repetition and just go over a few basic things.
 [options="header",cols="2*^"]
 |=========================
 | Symbol | Meaning
-| `#`    | decimal value
-| `#%`   | binary value
-| `#$`   | hexadecimal value
+| `+#+`    | decimal value
+| `+#+%`   | binary value
+| `+#+$`   | hexadecimal value
 | `$`    | memory address, expressed in hexadecimal
 | `.b`   | Byte
 | `.w`   | Word

--- a/tutorial-06.adoc
+++ b/tutorial-06.adoc
@@ -96,7 +96,7 @@ The memory area is most interesting, this is where the entire content of the mem
 By pressing `m`, you can type in the name of any memory tag (variable) that you are using,
 and see what the memory that it points to contains. If you're smart, you'll immediately type
 in `ff8240`, which will take you directly to the palette. Unfortunately, that will get you little,
-since this is protected memory, you'll only see `*`'s.
+since this is protected memory, you'll only see `+*+`'s.
 
 You can change between these areas by pressing tab, and you can only issue commands in
 the active area. When you are done debugging, you don't have to wait for the whole program

--- a/tutorial-07.adoc
+++ b/tutorial-07.adoc
@@ -69,7 +69,7 @@ as a coordinate system, then `C` would be at 3,5. We need to increment the point
 certain value for each coordinate, this shouldn't be to hard.
 
 Each line is 160 bytes, and each character is 32 lines. This means that for every Y coordinate,
-we need to increment the pointer by 32 × 160 bytes, right? Think about it, if we want `*`
+we need to increment the pointer by 32 × 160 bytes, right? Think about it, if we want `+*+`
 which is on the second line (1,0), we need to point to the font address + 32 lines down. Each
 character is 32 pixels wide, 16 pixels are 4 words, taking up 8 bytes, we need twice this. So
 for each X coordinate, we need to increment the pointer by 16 bytes.


### PR DESCRIPTION
For some reason, the inline code snippets with `#` in tutorial 4 don't seem to be working properly and most of them are not visible. This PR changes those inline code blocks to use the ``+#+`` syntax in Asciidoc which seems to work.